### PR TITLE
UpdateDialogCocoa: fix compile error "Update-Installer/src/UpdateDialogC...

### DIFF
--- a/src/UpdateDialogCocoa.mm
+++ b/src/UpdateDialogCocoa.mm
@@ -42,18 +42,14 @@ class UpdateDialogPrivate
 - (void) reportUpdateError: (id)arg
 {
 	dialog->hadError = true;
-	NSMutableString* message = [[NSMutableString alloc] init];
-	[message appendString:@"There was a problem installing the update:\n\n"];
-	[message appendString:arg];
 
 	NSAlert* alert = [NSAlert 
 		alertWithMessageText: @"Update Problem"
 	    defaultButton: nil
 	    alternateButton: nil
 	    otherButton: nil
-	    informativeTextWithFormat: message];
+	    informativeTextWithFormat: @"There was a problem installing the update:\n\n%@", arg];
 	[alert runModal];
-	[message release];
 }
 - (void) reportUpdateProgress: (id)arg
 {


### PR DESCRIPTION
...ocoa.mm:54:33: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security] informativeTextWithFormat: message];"
