### PR TITLE
Fix termination of DialogCocoa

### DIFF
--- a/src/UpdateDialogCocoa.mm
+++ b/src/UpdateDialogCocoa.mm
@@ -188,7 +188,7 @@ void UpdateDialogCocoa::releaseAutoreleasePool(void* arg)
 
 void UpdateDialogCocoa::quit()
 {
-	[NSApp performSelectorOnMainThread:@selector(stop:) withObject:d->delegate waitUntilDone:false];
+	[NSApp terminate:nil];
 }
 
 


### PR DESCRIPTION
The DialogCocoa would not quit if auto-close was set every time. This seems
to be some kind of race that can make the signals arrive in different order.
This small change fixes auto-close for all cases.
