### PR TITLE
Instead of always using the temporary file /tmp/libupdatergtk.so generat...

### DIFF
--- a/src/UpdateDialogGtkFactory.cpp
+++ b/src/UpdateDialogGtkFactory.cpp
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <vector>
 
 class UpdateDialogGtk;
 


### PR DESCRIPTION
...es a new name.

This solves a problem: if the file already existed and the current user
couldn't truncate it the auto update couldn't use the Gtk auto-updater.

In this commit it also deletes the file and avoids creating and closing
the file and opening again.

MD-20923
