### PR TITLE
Fix and comment config-template.js

### DIFF
--- a/tools/config-template.js
+++ b/tools/config-template.js
@@ -1,16 +1,23 @@
 {
+	// This file is the input to create-packages.rb. Its name ends in ".js" to
+	// look better in syntax highlighting, because normally JSON files don't
+	// contain comments (but Ruby's JSON parser allows them).
+
 	"packages" : {
 		// a single package which contains all files for the application
 		"app" : [
+			// Regular expression that will be applied to match which files
+			// should this package contain.
 			".*"
-		],
+		]
 	},
 	
-	// the name of the updater binary - this will be listed as
+	// the base file name of the updater binary - this will be listed as
 	// a dependency of the update process
 	"updater-binary" : "updater",
 
-	// the name of the main binary to launch when the
-	// application starts
+	// The name of the main binary to launch to start the application. Relative
+	// path from the input directory, so it could be "Contents/MacOS/myapp" on
+	// OS X if you use a bundle, or "bin/myapp" if follows FHS conventions.
 	"main-binary" : "myapp"
 }


### PR DESCRIPTION
The previous version had a bogus comma that broke the parsing. Also,
added lots of comments for beginners.